### PR TITLE
Remove screen with dependencies

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,6 @@ default.admin_essentials.packages = %w(
   mc
   htop
   strace
-  screen
   inotify-tools
   debconf-utils
   rlwrap

--- a/files/default/grml-pin
+++ b/files/default/grml-pin
@@ -6,10 +6,6 @@ Package: grml-etc-core
 Pin: release a=grml-stable
 Pin-Priority: 999
 
-Package: grml-scripts-core
-Pin: release a=grml-stable
-Pin-Priority: 999
-
 Package: grml-debian-keyring
 Pin: release a=grml-stable
 Pin-Priority: 999

--- a/recipes/grml-zsh.rb
+++ b/recipes/grml-zsh.rb
@@ -10,7 +10,6 @@ cookbook_file "grml-pin" do
 end
 
 package "grml-etc-core"
-package "grml-scripts-core"
 cookbook_file "/etc/tmux.conf" do
   mode "0644"
 end


### PR DESCRIPTION
tmux replaces screen. Therefor I kicked screen out. grml-scripts-core was only used for the screen-setup.
